### PR TITLE
Release tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,18 @@
+/.bundle/
+/.yardoc
+/Gemfile.lock
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+
+*.gem
+.byebug_history
+
+# rbenv
 .ruby-version
+
+# macOS
+.DS_Store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,7 @@ GEM
   specs:
     macaddr (1.7.1)
       systemu (~> 2.6.2)
+    rake (12.0.0)
     systemu (2.6.4)
 
 PLATFORMS
@@ -24,4 +25,9 @@ PLATFORMS
 
 DEPENDENCIES
   aead!
+  bundler
   gala!
+  rake
+
+BUNDLED WITH
+   1.14.3

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,10 @@
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+task default: :test

--- a/gala.gemspec
+++ b/gala.gemspec
@@ -1,22 +1,25 @@
-$LOAD_PATH.push File.expand_path("../lib", __FILE__)
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'gala/version'
 
-Gem::Specification.new do |s|
-  s.name              = "gala"
-  s.version           = Gala::VERSION
-  s.platform          = Gem::Platform::RUBY
-  s.authors           = ["Mark Bennett", "Ryan Daigle"]
-  s.email             = ["ryan@spreedly.com"]
-  s.homepage          = "https://github.com/spreedly/gala"
-  s.summary           = "Apple Pay payment token decryption library"
-  s.description       = "Given an (encrypted) Apple Pay token, verify and decrypt it"
+Gem::Specification.new do |spec|
+  spec.name              = "gala"
+  spec.version           = Gala::VERSION
+  spec.authors           = ["Mark Bennett", "Ryan Daigle"]
+  spec.email             = ["ryan@spreedly.com"]
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  spec.summary           = "Apple Pay payment token decryption library"
+  spec.description       = "Given an (encrypted) Apple Pay token, verify and decrypt it"
+  spec.homepage          = "https://github.com/spreedly/gala"
+  spec.license           = "MIT"
 
-  s.required_ruby_version = ">= 1.8.7"
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test)/}) }
+  spec.test_files    = `git ls-files -- test/*`.split("\n")
+  spec.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  spec.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'aead'
+  spec.required_ruby_version = ">= 1.8.7"
+
+  spec.add_runtime_dependency 'aead'
 end

--- a/gala.gemspec
+++ b/gala.gemspec
@@ -22,4 +22,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 1.8.7"
 
   spec.add_runtime_dependency 'aead'
+
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
 end

--- a/lib/gala/version.rb
+++ b/lib/gala/version.rb
@@ -1,3 +1,3 @@
 module Gala
-  VERSION = "0.3.0" unless defined? Gala::VERSION
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
Fixes #6.

- Cleaned up and updated the gemspec
- Updated .gitignore
- Added required development dependencies (Bundler and Rake)
- Added Rakefile with gem tasks

To release the gem just bump the version and then run `$ rake release`. The task will take care of the rest.

@rwdaigle 