### PR TITLE
Use Shopify aead instead of OneLogin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 gemspec
 
-gem 'aead', github: 'onelogin/aead', ref: 'master'
+gem 'aead', github: 'shopify/aead', ref: '340e7718d8bd9c1fcf3c443e32f439436ea2b70d'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,15 @@
 GIT
-  remote: git://github.com/onelogin/aead.git
-  revision: 16475b876c2cd02951db8952c92214244204d11b
-  ref: master
+  remote: git://github.com/shopify/aead.git
+  revision: 340e7718d8bd9c1fcf3c443e32f439436ea2b70d
+  ref: 340e7718d8bd9c1fcf3c443e32f439436ea2b70d
   specs:
-    aead (1.8.1)
+    aead (1.8.2)
       macaddr (~> 1)
 
 PATH
   remote: .
   specs:
-    gala (0.3.0)
+    gala (0.3.1)
       aead
 
 GEM
@@ -17,7 +17,7 @@ GEM
   specs:
     macaddr (1.7.1)
       systemu (~> 2.6.2)
-    systemu (2.6.4)
+    systemu (2.6.5)
 
 PLATFORMS
   ruby
@@ -25,3 +25,6 @@ PLATFORMS
 DEPENDENCIES
   aead!
   gala!
+
+BUNDLED WITH
+   1.13.7

--- a/lib/gala/version.rb
+++ b/lib/gala/version.rb
@@ -1,3 +1,3 @@
 module Gala
-  VERSION = "0.3.0" unless defined? Gala::VERSION
+  VERSION = "0.3.1" unless defined? Gala::VERSION
 end


### PR DESCRIPTION
There a compatibiliy issue with Ruby 2.2+ which causes the following
error when trying to decrypt the payment_data blog:

`TypeError (wrong argument type OpenSSL::Cipher (expected Data))`

Unfortunately the the fix is not being merged in to the OneLogin aead
repo. However, Shopify has fixed this in their fork from OneLogin so
this updates to point to Shopify's aead so Gala works in Ruby >= 2.2.0

See https://github.com/onelogin/aead/issues/8 for more details on the issue.