### PR TITLE
Check signature's signed time

### DIFF
--- a/lib/gala/payment_token.rb
+++ b/lib/gala/payment_token.rb
@@ -69,6 +69,9 @@ module Gala
           verified = p7.verify([], store, verification_string, OpenSSL::PKCS7::NOVERIFY )
           raise InvalidSignatureError, "The given signature is not a valid ECDSA signature." unless verified
         end
+
+        # Ensure that the signing time is within "a few minutes"
+        raise InvalidSignatureError, "Token not signed within a few minutes" unless p7.signers.length == 1 && p7.signers.first.signed_time.between?(Time.now - 5*60, Time.now + 5*60)
       end
 
       def chain_of_trust_verified?(leaf_cert, intermediate_cert, root_cert)


### PR DESCRIPTION
I hand-picked the number 5 to substitute for "few" in

> If the time signature and the transaction time differ by more than a few minutes, it's possible that the token is a replay attack.

https://developer.apple.com/library/content/documentation/PassKit/Reference/PaymentTokenJSON/PaymentTokenJSON.html

YMMV

Ref. https://github.com/spreedly/gala/pull/3#issuecomment-164321362