### PR TITLE
Update Gala Dependencies 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
   specs:
     minitest (5.17.0)
     openssl (3.1.0)
-    rake (12.3.3)
+    rake (13.0.6)
 
 PLATFORMS
   x86_64-darwin-20
@@ -19,7 +19,7 @@ DEPENDENCIES
   bundler (~> 2.3)
   gala!
   minitest
-  rake (~> 12.0)
+  rake (~> 13.0)
 
 BUNDLED WITH
    2.3.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
   specs:
     minitest (5.17.0)
     openssl (3.1.0)
-    rake (13.0.6)
+    rake (12.3.3)
 
 PLATFORMS
   x86_64-darwin-20
@@ -19,7 +19,7 @@ DEPENDENCIES
   bundler (~> 2.3)
   gala!
   minitest
-  rake (~> 13.0)
+  rake (~> 12.0)
 
 BUNDLED WITH
    2.3.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,25 @@
 PATH
   remote: .
   specs:
-    gala (0.3.2)
-      openssl (~> 2.0)
+    gala (0.4.0)
+      openssl (>= 3.0.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    minitest (5.11.3)
-    openssl (2.1.0)
-    rake (12.3.1)
+    minitest (5.17.0)
+    openssl (3.1.0)
+    rake (12.3.3)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-20
+  x86_64-darwin-21
 
 DEPENDENCIES
-  bundler (~> 1.14)
+  bundler (~> 2.3)
   gala!
   minitest
   rake (~> 12.0)
 
 BUNDLED WITH
-   1.16.1
+   2.3.4

--- a/gala.gemspec
+++ b/gala.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'openssl', '>= 3.0.1'
 
   spec.add_development_dependency 'bundler', '~> 2.3'
-  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'minitest'
 end

--- a/gala.gemspec
+++ b/gala.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'openssl', '>= 3.0.1'
 
   spec.add_development_dependency 'bundler', '~> 2.3'
-  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'minitest'
 end

--- a/gala.gemspec
+++ b/gala.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4.0'
 
-  spec.add_runtime_dependency 'openssl', '~> 2.0'
+  spec.add_runtime_dependency 'openssl', '>= 3.0.1'
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'bundler', '~> 2.3'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'minitest'
 end


### PR DESCRIPTION
Update Gala to use newer dependencies and be compatible with newer Ruby versions